### PR TITLE
Add exec flag to run commands with selected JVM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v12
+To be released
+
+* Support running arbitrary programs with $JAVA_HOME and $PATH set according
+  to requested Java version (#11)
+
 ## v11
 2025-01-03
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## v12
-To be released
+2026-02-20
 
 * Support running arbitrary programs with $JAVA_HOME and $PATH set according
-  to requested Java version (#11)
+  to requested Java version (#11, #12)
 
 ## v11
 2025-01-03

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017, 2018, 2019, 2020, 2023, 2024 Michael Lass
+Copyright (c) 2017–2026 Michael Lass
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -12,14 +12,16 @@ this version, the one corresponding to the user's default JVM is used.
 By default, archlinux-java-run will execute a suitable version of java
 with the given JAVA_ARGS. When run with -j|--java-home, it just prints
 the location of a suitable java installation so that custom commands
-can be run.
+can be run. When run with -e|--exec, it will run EXEC_CMD in an
+environment where $JAVA_HOME and $PATH is set so that the appropriate
+Java version is used.
 
 ## Usage
 ```
   archlinux-java-run [-a|--min MIN] [-b|--max MAX] [-p|--package PKG]
                      [-f|--feature FEATURE] [-h|--help] [-v|--verbose]
-                     [-d|--dry-run] [-j|--java-home]
-                     -- JAVA_ARGS
+                     [-d|--dry-run] [-j|--java-home] [-e|--exec]
+                     -- <JAVA_ARGS | EXEC_CMD>
 ```
 
 ## Available features
@@ -45,3 +47,6 @@ can be run.
 
 * Launch javac from a JDK in version 11 or newer:
   `JAVA_HOME=$(archlinux-java-run --min 11 --feature jdk --java-home) && "$JAVA_HOME"/bin/javac ...`
+
+* Launch interactive bash with Java 25 set as $JAVA_HOME and as first element in $PATH:
+  `archlinux-java-run --min 25 --max 25 --exec -- bash -i`

--- a/archlinux-java-run.sh
+++ b/archlinux-java-run.sh
@@ -86,6 +86,8 @@ EXAMPLES:
       && "\$JAVA_HOME"/bin/javac ...
     (launches javac from a JDK in version 11 or newer)
 
+  archlinux-java-run --min 25 --max 25 --exec -- bash -i
+    (launches interactive bash with Java 25 set as \$JAVA_HOME and as first element in \$PATH)
 EOF
 }
 

--- a/archlinux-java-run.sh
+++ b/archlinux-java-run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# (c) 2017, 2018, 2019, 2020, 2023, 2024 Michael Lass
+# Copyright (c) 2017–2026 Michael Lass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/archlinux-java-run.sh
+++ b/archlinux-java-run.sh
@@ -25,7 +25,7 @@
 # This script uses `exec` on purpose to launch a suitable JRE before the end of
 # the script.
 # shellcheck disable=SC2093
-VERSION=11
+VERSION=12
 JAVADIR=###JAVADIR###
 
 JAVAFX_MODULES=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.media,javafx.swing,javafx.web

--- a/archlinux-java-run.sh
+++ b/archlinux-java-run.sh
@@ -37,7 +37,7 @@ USAGE:
   archlinux-java-run [-a|--min MIN] [-b|--max MAX] [-p|--package PKG]
                      [-f|--feature FEATURE] [-h|--help] [-v|--verbose]
                      [-d|--dry-run] [-j|--java-home] [-e|--exec]
-                     -- <JAVA_ARGS | EXEC_ARGS>
+                     -- <JAVA_ARGS | EXEC_CMD>
 
 EOF
 }
@@ -58,7 +58,9 @@ this version, the one corresponding to the user's default JVM is used.
 By default, archlinux-java-run will execute a suitable version of java
 with the given JAVA_ARGS. When run with -j|--java-home, it just prints
 the location of a suitable java installation so that custom commands
-can be run.
+can be run. When run with -e|--exec, it will run EXEC_CMD in an
+environment where \$JAVA_HOME and \$PATH is set so that the appropriate
+Java version is used.
 EOF
   print_usage
   cat << EOF
@@ -193,7 +195,7 @@ function generate_candiates {
   echo "$list" | xargs
 }
 
-function env_switch_java_home() {
+function exec_in_modified_env() {
   quote_args
 
   if [ $dryrun -eq 1 ]; then
@@ -377,8 +379,7 @@ for ver in $candidates; do
   fi
 
   if [ $exec -eq 1 ]; then
-    env_switch_java_home
-    exit 0
+    exec_in_modified_env
   fi
 
   for ft in "${features[@]}"; do


### PR DESCRIPTION
Allow running arbitrary commands with JAVA_HOME and PATH set to the selected JVM.

Authored by @ahmubashshir

Discussed in https://github.com/michaellass/archlinux-java-run/issues/11